### PR TITLE
Update presubmit.yml

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,7 @@
 tasks:
   verify_build_targets:
     name: Verify Build targets on macOS
-    platform: macos
+    platform: macos_arm64
+    bazel: "7.x"
     build_targets:
       - "@swift_bep_parser//SwiftBEPParser/Sources:SwiftBEPParser"


### PR DESCRIPTION
Try to use new BCR `macos_arm64` and Bazel definition to fix broken BRC builds.