### PR TITLE
Enable `--nolegacy_important_outputs`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -54,6 +54,10 @@ build:remote_cache --remote_timeout=3600
 # https://bazel.build/reference/command-line-reference#flag--experimental_remote_cache_compression
 build:remote_cache --experimental_remote_cache_compression
 
+# Significantly reduce the payload size of the uploaded build event
+# stream by eliminating duplicate file references
+build --nolegacy_important_outputs
+
 # By default don't upload local results to remote cache, only CI does this.
 build --noremote_upload_local_results
 build:ci --remote_upload_local_results


### PR DESCRIPTION
BuildBuddy suggests this to Significantly reduce the payload size of the uploaded build event stream by eliminating duplicate file references.