### PR TITLE
Set rules_swift max_compatibility_level to 2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,7 @@ bazel_dep(
 bazel_dep(
     name = "rules_swift",
     version = "1.18.0",
+    max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(


### PR DESCRIPTION
Declare support for `rules_swift` 2.0+

Tested bumping rules_swift locally, and it's a simple lib to boot.